### PR TITLE
- .htaccess to blacklist of deploy

### DIFF
--- a/.github/workflows/multiflow.yml
+++ b/.github/workflows/multiflow.yml
@@ -59,5 +59,4 @@ jobs:
               **/build/
               /README.md
               .gitignore
-              .htaccess
               .env.exemple


### PR DESCRIPTION
Ajout du htaccess au deploy car peut crée des erreurs